### PR TITLE
docs: agregar retrospectiva del Sprint 2

### DIFF
--- a/retro.md
+++ b/retro.md
@@ -46,3 +46,55 @@
 ## 📝 Conclusión general
 
 El Sprint 1 fue útil para sentar las bases del proyecto. La temática quedó bien definida y los referentes ayudaron mucho a tener claridad visual. Para el Sprint 2 el foco va a estar en trasladar esos wireframes a HTML y CSS real, con buenas prácticas desde el principio: semántica correcta, estilos organizados y el tablero de trabajo activo.
+
+---
+
+# 🌟 Retrospectiva — Sprint 2
+
+**Proyecto:** LuBo — Marketplace de recursos para diseño de indumentaria  
+**Dinámica:** Estrella de Mar
+
+---
+
+## ⬆️ Comenzar a hacer
+
+- Hacer commits frecuentes con mensajes descriptivos usando prefijos convencionales (feat:, fix:, docs:, etc.).
+- Documentar las historias de usuario en el tablero antes de empezar a codear.
+- Actualizar el README al final de cada sprint reflejando los cambios realizados.
+
+---
+
+## ➕ Hacer más
+
+- Detallar el contenido de las carpetas del proyecto (como `/design`) en el README para que quede claro qué hay en cada una.
+- Documentar las decisiones de UX en el repositorio para dejar registro del razonamiento.
+- Incluir el user persona en los entregables de diseño desde el inicio del sprint.
+
+---
+
+## ✅ Continuar haciendo
+
+- Definir una temática clara y diferenciada desde el principio del sprint.
+- Cubrir todos los flujos principales en los wireframes (home, detalle, carrito, registro y login).
+- Tomar decisiones de accesibilidad desde el diseño (paleta apta para daltonismo).
+- Seleccionar referentes reales y específicos del nicho para orientar las decisiones visuales.
+
+---
+
+## ➖ Hacer menos
+
+- Acumular cambios en pocos commits grandes en lugar de ir commiteando de forma atómica.
+- Asumir los requisitos sin revisar en detalle las consignas antes de arrancar.
+
+---
+
+## 🛑 Dejar de hacer
+
+- Dejar la documentación para el final del sprint.
+- Tomar decisiones de diseño sin tener el user persona definido.
+
+---
+
+## 📝 Conclusión general
+
+El Sprint 2 consolidó la identidad visual del proyecto y completó el maquetado de las páginas principales. La paleta, los wireframes y los referentes quedaron bien definidos. Para el Sprint 3 el foco va a estar en agregar dinamismo al sitio con Express y EJS: separar los componentes repetidos en partials, organizar las vistas en carpetas y conectar todo con controladores y rutas.


### PR DESCRIPTION
Retrospectiva del Sprint 2 completada y documentada en el archivo **`retro.md`**.

**Commit asociado:**

`docs: agregar retrospectiva del Sprint 2`

**Incluye:**

- Qué hicimos bien (wireframes, temática, paleta accesible, referentes).
- Qué hicimos mal (sin user persona, commits sin mensajes, carpeta /design sin describir).
- Qué empezar a hacer (commits descriptivos, documentar decisiones de UX).
- Qué dejar de hacer (documentar al final del sprint, commits atómicos ignorados).

Close #23 