### PR TITLE
refactor: migrar todas las vistas de .html a .ejs

### DIFF
--- a/src/controllers/main.controller.js
+++ b/src/controllers/main.controller.js
@@ -1,6 +1,6 @@
-const mainController = {  
-    home: (req, res) => res.send('home - próximamente EJS'),
-    cart: (req, res) => res.send('carrito - próximamente EJS'),
+const mainController = {
+    home: (req, res) => res.render('index', {title:'LuBo – Recursos para Indumentaria'}),
+    cart: (req, res) => res.render('cart',  { title:'Mi Carrito – LuBo'}),
 };
 
 module.exports = mainController;

--- a/src/views/404.ejs
+++ b/src/views/404.ejs
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="es">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Mi Carrito — LuBo</title>
+        <link rel="stylesheet" href="../styles/main.css">
+    </head>
+<body>
+    
+    <!-- HEADER -->
+    <header class="site-header">
+        <nav class="container nav-inner">
+            <a href="index.html" class="logo">
+                <img src="../assets/image/logo.svg" alt="LuBo - Ludmila Borrelli">
+            </a>
+            <ul class="nav-links">
+                <li><a href="index.html">Inicio</a></li>
+                <li><a href="productDetail.html">Productos</a></li>
+                <li><a href="#about">Nosotros</a></li>
+            </ul>
+            <button class="btn-hamburger" onclick="this.closest('nav').querySelector('.nav-links').classList.toggle('open')">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
+            <div class="nav-actions">
+                <a href="login.html" class="btn btn-outline btn-sm">Ingresar</a>
+                <a href="cart.html" class="btn-icon" title="Carrito">
+                    <img src="../assets/image/carrito.svg" alt="Carrito">
+                </a>
+            </div>
+        </nav>
+    </header>
+
+    <!-- MAIN -->
+    <main class="page-content page-404">
+        <div class="container text-center">
+            <h1 class="error-code">404</h1>
+            <p class="error-msg">La página que buscás no existe.</p>
+            <a href="/" class="btn-primary">Volver al inicio</a>
+        </div>
+    </main>
+    
+    <!-- FOOTER -->
+    <footer class="site-footer">
+        <div class="container">
+            <div class="footer-grid">
+                <div class="footer-brand">
+                    <div class="footer-logo">
+                        <a href="index.html">
+                            <img src="../assets/image/logo.svg" alt="LuBo - Ludmila Borrelli">
+                        </a>
+                    </div>
+                    <p class="footer-desc">Marketplace de recursos digitales para diseñadores de indumentaria, creado por Ludmila Borrelli.</p>
+                </div>
+                <div>
+                    <p class="footer-col-title">Sitio</p>
+                    <ul class="footer-links">
+                        <li><a href="index.html">Inicio</a></li>
+                        <li><a href="productDetail.html">Productos</a></li>
+                        <li><a href="#about">Cómo funciona</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <p class="footer-col-title">Cuenta</p>
+                    <ul class="footer-links">
+                        <li><a href="register.html">Registrarme</a></li>
+                        <li><a href="login.html">Ingresar</a></li>
+                        <li><a href="cart.html">Mi carrito</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <span>© 2026 LuBo — Ludmila Borrelli. Todos los derechos reservados.</span>
+                <span>Diseño por Francisco Schlusselblum · Digital House DPFS</span>
+            </div>
+        </div>
+    </footer>
+
+</body>
+</html>

--- a/src/views/cart.ejs
+++ b/src/views/cart.ejs
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mi Carrito — LuBo</title>
+    <link rel="stylesheet" href="../styles/main.css">
+</head>
+<body>
+    
+    <!-- HEADER -->
+    <header class="site-header">
+        <nav class="container nav-inner">
+            <a href="index.html" class="logo">
+                <img src="../assets/image/logo.svg" alt="LuBo - Ludmila Borrelli">
+            </a>
+            <ul class="nav-links">
+                <li><a href="index.html">Inicio</a></li>
+                <li><a href="productDetail.html">Productos</a></li>
+                <li><a href="#about">Nosotros</a></li>
+            </ul>
+            <button class="btn-hamburger" onclick="this.closest('nav').querySelector('.nav-links').classList.toggle('open')">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
+            <div class="nav-actions">
+                <a href="login.html" class="btn btn-outline btn-sm">Ingresar</a>
+                <a href="cart.html" class="btn-icon" title="Carrito">
+                    <img src="../assets/image/carrito.svg" alt="Carrito">
+                </a>
+            </div>
+        </nav>
+    </header>
+
+    <!-- MAIN -->
+    <main class="container cart-page">
+ 
+        <h1 class="page-title">Mi carrito</h1>
+        <p class="cart-count-label">2 productos</p>
+    
+        <div class="cart-layout">
+    
+            <div>
+                <div class="cart-items">
+        
+                    <div class="cart-item">
+                        <div class="cart-item-img">
+                            <img src="https://placehold.co/80x80/E8DDD4/8C8480?text=TP" alt="Tech Pack" />
+                        </div>
+                        <div class="cart-item-info">
+                            <p class="cart-item-category">Tech Pack</p>
+                            <h3 class="cart-item-name">Tech Pack Básico — Remeras</h3>
+                            <p class="cart-item-format">.xlsx + .pdf editable</p>
+                        </div>
+                        <div class="cart-item-actions">
+                            <span class="cart-item-price">$1.200</span>
+                            <button class="btn-remove">✕ Eliminar</button>
+                        </div>
+                    </div>
+            
+                    <div class="cart-item">
+                        <div class="cart-item-img">
+                            <img src="https://placehold.co/80x80/DDD5CC/8C8480?text=FP" alt="Flat Pack" />
+                        </div>
+                        <div class="cart-item-info">
+                            <p class="cart-item-category">Diseños Técnicos</p>
+                            <h3 class="cart-item-name">Pack Flats — Pantalones</h3>
+                            <p class="cart-item-format">12 archivos .ai vectorizados</p>
+                        </div>
+                        <div class="cart-item-actions">
+                            <span class="cart-item-price">$2.800</span>
+                            <button class="btn-remove">✕ Eliminar</button>
+                        </div>
+                    </div>  
+        
+                </div>
+        
+                <div class="cart-back">
+                    <a href="productDetail.html" class="btn btn-outline btn-sm">← Seguir comprando</a>
+                </div>
+            </div>
+        
+            <div class="order-summary">
+                <h2 class="summary-title">Resumen del pedido</h2>
+        
+                <div class="summary-rows">
+                    <div class="summary-row">
+                        <span class="label">Tech Pack Básico</span>
+                        <span class="value">$1.200</span>
+                    </div>
+                    <div class="summary-row">
+                        <span class="label">Pack Flats — Pantalones</span>
+                        <span class="value">$2.800</span>
+                    </div>
+                    <div class="summary-row">
+                        <span class="label">Descuento aplicado</span>
+                        <span class="value value-discount">−$600</span>
+                    </div>
+                    <div class="summary-row total">
+                        <span class="label">Total</span>
+                        <span class="value">$3.400</span>
+                    </div>
+                </div>
+        
+                <div class="coupon-row">
+                    <input type="text" class="coupon-input" placeholder="Código de descuento" />
+                    <button class="btn btn-outline btn-sm">Aplicar</button>
+                </div>
+        
+                <a href="register.html" class="btn btn-accent btn-full btn-lg">Finalizar compra</a>
+        
+                <p class="security-note">🔒 Pago 100% seguro · Mercado Pago</p>
+            </div>
+    
+        </div>
+    </main>
+
+    <!-- FOOTER -->
+    <footer class="site-footer">
+        <div class="container">
+            <div class="footer-grid">
+                <div class="footer-brand">
+                    <div class="footer-logo">
+                        <a href="index.html">
+                            <img src="../assets/image/logo.svg" alt="LuBo - Ludmila Borrelli">
+                        </a>
+                    </div>
+                    <p class="footer-desc">Marketplace de recursos digitales para diseñadores de indumentaria, creado por Ludmila Borrelli.</p>
+                </div>
+                <div>
+                    <p class="footer-col-title">Sitio</p>
+                    <ul class="footer-links">
+                        <li><a href="index.html">Inicio</a></li>
+                        <li><a href="productDetail.html">Productos</a></li>
+                        <li><a href="#about">Cómo funciona</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <p class="footer-col-title">Cuenta</p>
+                    <ul class="footer-links">
+                        <li><a href="register.html">Registrarme</a></li>
+                        <li><a href="login.html">Ingresar</a></li>
+                        <li><a href="cart.html">Mi carrito</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <span>© 2026 LuBo — Ludmila Borrelli. Todos los derechos reservados.</span>
+                <span>Diseño por Francisco Schlusselblum · Digital House DPFS</span>
+            </div>
+        </div>
+    </footer>
+
+</body>
+</html>

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -1,0 +1,210 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>LuBo — Recursos para Diseño de Indumentaria</title>
+    <link rel="stylesheet" href="./styles/main.css">
+</head>
+<body>
+    
+    <!-- HEADER -->
+    <header class="site-header">
+        <nav class="container nav-inner">
+            <a href="index.html" class="logo">
+                <img src="../assets/image/logo.svg" alt="LuBo - Ludmila Borrelli">
+            </a>
+            <ul class="nav-links">
+                <li><a href="index.html">Inicio</a></li>
+                <li><a href="productDetail.html">Productos</a></li>
+                <li><a href="#about">Nosotros</a></li>
+            </ul>
+            <button class="btn-hamburger" onclick="this.closest('nav').querySelector('.nav-links').classList.toggle('open')">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
+            <div class="nav-actions">
+                <a href="login.html" class="btn btn-outline btn-sm">Ingresar</a>
+                <a href="cart.html" class="btn-icon" title="Carrito">
+                    <img src="../assets/image/carrito.svg" alt="Carrito">
+                </a>
+            </div>
+        </nav>
+    </header>
+
+    <!-- MAIN -->
+    <main>
+        <section class="hero">
+            <div class="container">
+            <div class="hero-inner">
+                <p class="hero-eyebrow">Marketplace de diseño de indumentaria</p>
+                <h1>Recursos digitales para<em> crear mejor</em></h1>
+                <p>Tech packs, moldes, diseños técnicos y recursos listos para usar. Pensados por una diseñadora, para diseñadores.</p>
+                <div class="hero-actions">
+                <a href="productDetail.html" class="btn btn-accent">Ver productos</a>
+                <a href="register.html" class="btn btn-ghost">Crear cuenta</a>
+                </div>
+            </div>
+            </div>
+        </section>
+        
+        <div class="categories-strip">
+            <div class="container categories-scroll">
+            <span>Tech Packs</span>
+            <span>Diseños Técnicos (Flats)</span>
+            <span>Moldes &amp; Patrones</span>
+            <span>Recursos Digitales</span>
+            <span>Fichas de Producción</span>
+            <span>Templates</span>
+            </div>
+        </div>
+        
+        <section class="section">
+            <div class="container">
+            <div class="featured-header">
+                <div>
+                <span class="eyebrow">Destacados</span>
+                <h2>Nuevos recursos</h2>
+                </div>
+                <a href="productDetail.html" class="btn btn-outline">Ver todos</a>
+            </div>
+        
+            <div class="product-grid">
+        
+                <article class="product-card">
+                <a href="productDetail.html">
+                    <div class="product-card-img">
+                    <img src="https://placehold.co/400x300/E8DDD4/8C8480?text=Tech+Pack" alt="Tech Pack básico" />
+                    </div>
+                    <div class="product-card-body">
+                    <p class="product-category">Tech Pack</p>
+                    <h3 class="product-name">Tech Pack Básico — Remeras</h3>
+                    <p class="product-desc">Ficha técnica completa para remeras básicas, lista para completar.</p>
+                    <p class="product-price">$1.200</p>
+                    </div>
+                </a>
+                </article>
+        
+                <article class="product-card">
+                <a href="productDetail.html">
+                    <div class="product-card-img">
+                    <img src="https://placehold.co/400x300/DDD5CC/8C8480?text=Flat+Pack" alt="Pack de flats" />
+                    </div>
+                    <div class="product-card-body">
+                    <p class="product-category">Diseños Técnicos</p>
+                    <h3 class="product-name">Pack Flats — Pantalones</h3>
+                    <p class="product-desc">12 diseños técnicos vectorizados para pantalones de distintos cortes.</p>
+                    <p class="product-price">$2.800</p>
+                    </div>
+                </a>
+                </article>
+        
+                <article class="product-card">
+                <a href="productDetail.html">
+                    <div class="product-card-img">
+                    <img src="https://placehold.co/400x300/ECDFD5/8C8480?text=Moldes" alt="Moldes básicos" />
+                    </div>
+                    <div class="product-card-body">
+                    <p class="product-category">Moldes</p>
+                    <h3 class="product-name">Kit Moldes Base — Talle S a XL</h3>
+                    <p class="product-desc">Moldes base en PDF escalables para confección propia.</p>
+                    <p class="product-price">$3.500</p>
+                    </div>
+                </a>
+                </article>
+        
+                <article class="product-card">
+                <a href="productDetail.html">
+                    <div class="product-card-img">
+                    <img src="https://placehold.co/400x300/E0D7CE/8C8480?text=Template" alt="Template producción" />
+                    </div>
+                    <div class="product-card-body">
+                    <p class="product-category">Template</p>
+                    <h3 class="product-name">Template de Producción Excel</h3>
+                    <p class="product-desc">Planilla de seguimiento de producción para talleres y marcas.</p>
+                    <p class="product-price">$950</p>
+                    </div>
+                </a>
+                </article>
+        
+            </div>
+            </div>
+        </section>
+        
+        <div class="container">
+            <div class="promo-banner">
+            <div class="promo-text">
+                <span class="eyebrow">Para emprendedores</span>
+                <h2>Ahorrá tiempo,<br>invertí en tu marca</h2>
+                <p>Recursos profesionales a una fracción del costo de un estudio de diseño.</p>
+            </div>
+            <a href="register.html" class="btn btn-primary">Empezar ahora</a>
+            </div>
+        </div>
+        
+        <section class="section" id="about">
+            <div class="container">
+            <div class="section-header">
+                <span class="eyebrow">¿Cómo funciona?</span>
+                <h2>Simple, rápido y descargable</h2>
+            </div>
+            <div class="steps-grid">
+                <div class="step">
+                <div class="step-num">01</div>
+                <h3>Elegí tu recurso</h3>
+                <p>Navegá el catálogo y encontrá el recurso que necesitás para tu colección.</p>
+                </div>
+                <div class="step">
+                <div class="step-num">02</div>
+                <h3>Comprá de forma segura</h3>
+                <p>Pagá con Mercado Pago o tarjeta. Proceso 100% seguro y sin complicaciones.</p>
+                </div>
+                <div class="step">
+                <div class="step-num">03</div>
+                <h3>Descargá y usá</h3>
+                <p>Recibís el archivo en tu mail y en tu cuenta. Listo para usar de inmediato.</p>
+                </div>
+            </div>
+            </div>
+        </section>
+    </main>
+
+    <!-- FOOTER -->
+    <footer class="site-footer">
+        <div class="container">
+            <div class="footer-grid">
+                <div class="footer-brand">
+                    <div class="footer-logo">
+                        <a href="index.html">
+                            <img src="../assets/image/logo.svg" alt="LuBo - Ludmila Borrelli">
+                        </a>
+                    </div>
+                    <p class="footer-desc">Marketplace de recursos digitales para diseñadores de indumentaria, creado por Ludmila Borrelli.</p>
+                </div>
+                <div>
+                    <p class="footer-col-title">Sitio</p>
+                    <ul class="footer-links">
+                        <li><a href="index.html">Inicio</a></li>
+                        <li><a href="productDetail.html">Productos</a></li>
+                        <li><a href="#about">Cómo funciona</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <p class="footer-col-title">Cuenta</p>
+                    <ul class="footer-links">
+                        <li><a href="register.html">Registrarme</a></li>
+                        <li><a href="login.html">Ingresar</a></li>
+                        <li><a href="cart.html">Mi carrito</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <span>© 2026 LuBo — Ludmila Borrelli. Todos los derechos reservados.</span>
+                <span>Diseño por Francisco Schlusselblum · Digital House DPFS</span>
+            </div>
+        </div>
+    </footer>
+
+</body>
+</html>


### PR DESCRIPTION
Todas las vistas fueron renombradas de **`.html`** a **`.ejs`**. Los controladores fueron actualizados para usar **`res.render()`** en lugar de **`res.sendFile()`**.

**Commit asociado:**

`refactor: migrar todas las vistas de .html a .ejs`

- No quedan archivos **`.html`** en la carpeta views.
- Todos los controladores usan **`res.render()`** con el nombre del archivo **`.ejs`**.
- Se verificó que cada vista renderiza sin errores desde su ruta correspondiente.

Close #26  
