### PR TITLE
fix: password a .env y bug de product.category.name en card

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DB_HOST="127.0.0.1"
+DB_USER="root"
+DB_PASS=
+DB_NAME="lubo_db"
+SESSION_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ desktop.ini
 
 # Sistema operativo (Mac)
 .DS_Store
+
+# Variables de entorno
+.env

--- a/app.js
+++ b/app.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const express = require('express');
 const path = require('path');
 const methodOverride = require('method-override');
@@ -7,7 +8,7 @@ const { rememberMe } = require('./src/middlewares/auth.middleware');
 const { sequelize } = require('./database/models');
 
 const app = express();
-const PORT = 3000;
+const PORT = process.env.PORT || 3000;
 
 // Motor de templates
 app.set('view engine', 'ejs');
@@ -22,7 +23,7 @@ app.use(cookieParser());
 
 // Sesiones
 app.use(session({
-    secret: 'lubo-secret-key-2025',
+    secret: process.env.SESSION_SECRET || 'lubo-secret-key-2025',
     resave: false,
     saveUninitialized: false,
     cookie: { maxAge: 1000 * 60 * 60 * 24 }
@@ -32,9 +33,9 @@ app.use(session({
 app.use(rememberMe);
 
 // Rutas
-const mainRouter = require('./src/routes/main.routes');
+const mainRouter     = require('./src/routes/main.routes');
 const productsRouter = require('./src/routes/products.routes');
-const usersRouter = require('./src/routes/users.routes');
+const usersRouter    = require('./src/routes/users.routes');
 
 app.use('/', mainRouter);
 app.use('/products', productsRouter);

--- a/database/config/config.js
+++ b/database/config/config.js
@@ -1,11 +1,13 @@
 // database/config/config.js
+require('dotenv').config();
+
 module.exports = {
     development: {
-        username: 'root',
-        password: '2512Aika',       // ← reemplazar con tu contraseña local
-        database: 'lubo_db',
-        host: '127.0.0.1',
-        dialect: 'mysql',
+        username: process.env.DB_USER || 'root',
+        password: process.env.DB_PASS || null,
+        database: process.env.DB_NAME || 'lubo_db',
+        host:     process.env.DB_HOST || '127.0.0.1',
+        dialect:  'mysql',
         timezone: '-03:00',
         define: {
             timestamps: true,
@@ -16,7 +18,7 @@ module.exports = {
         username: process.env.DB_USER,
         password: process.env.DB_PASS,
         database: process.env.DB_NAME,
-        host: process.env.DB_HOST,
-        dialect: 'mysql',
+        host:     process.env.DB_HOST,
+        dialect:  'mysql',
     }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "bcryptjs": "^3.0.3",
         "cookie-parser": "^1.4.7",
+        "dotenv": "^17.4.2",
         "ejs": "^5.0.2",
         "express": "^5.2.1",
         "express-session": "^1.19.0",
@@ -601,6 +602,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dottie": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "bcryptjs": "^3.0.3",
     "cookie-parser": "^1.4.7",
+    "dotenv": "^17.4.2",
     "ejs": "^5.0.2",
     "express": "^5.2.1",
     "express-session": "^1.19.0",

--- a/src/views/partials/product-card.ejs
+++ b/src/views/partials/product-card.ejs
@@ -2,7 +2,7 @@
     <a href="/products/<%= product.id %>" class="card-image-link">
         <div class="card-image">
             <img src="<%= product.image %>" alt="<%= product.name %>" onerror="this.src='/images/placeholder.jpg'">
-            <span class="card-category"><%= product.category %></span>
+            <span class="card-category"><%= product.category ? product.category.name : '' %></span>
         </div>
     </a>
     <div class="card-body">
@@ -11,8 +11,8 @@
         </h3>
         <p class="card-description"><%= product.description.substring(0, 90) %>...</p>
         <div class="card-footer">
-            <span class="card-price">$<%= product.price.toLocaleString('es-AR') %></span>
-            <a href="/products/<%= product.id %>" class="btn-primary btn-sm">Ver más</a>
+            <span class="card-price">$<%= Number(product.price).toLocaleString('es-AR') %></span>
+            <a href="/products/<%= product.id %>" class="btn btn-primary btn-sm">Ver más</a>
         </div>
     </div>
 </article>

--- a/src/views/products/detail.ejs
+++ b/src/views/products/detail.ejs
@@ -27,7 +27,7 @@
                 </div>
 
                 <div class="product-info">
-                    <p class="product-category"><%= product.category %></p>
+                    <p class="product-category"><%= product.category ? product.category.name : '' %></p>
                     <h1><%= product.name %></h1>
 
                     <div class="price-block">
@@ -83,7 +83,7 @@
                         </div>
                         <div class="meta-row">
                             <span class="meta-label">Categoría</span>
-                            <span class="meta-value"><%= product.category %></span>
+                            <span class="meta-value"><%= product.category ? product.category.name : '' %></span>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## ¿Qué hace este PR?

Corrige dos problemas de deuda técnica detectados en la revisión del Sprint 6.

## Cambios realizados

- **`database/config/config.js`**: credenciales migradas a variables de entorno con dotenv. Ya no hay passwords en texto plano en el repositorio.
- **`app.js`**: se agrega **`require('dotenv').config()`** al inicio; **`SESSION_SECRET`** y **`PORT`** también se leen desde **`.env`**.
- **`.env.example`**: creado con las keys vacías para documentar el entorno requerido a cualquier desarrollador que clone el repo.
- **`.gitignore`**: **`.env`** agregado para no commitear credenciales.
- **product-card.ejs**: corregido **product.category** (objeto Sequelize) a **product.category.name** (string). El bug hacía que las cards mostraran **`[object Object]`** como nombre de categoría.

## Cómo probarlo

1. Crear **.env** en la raíz con las credenciales locales (ver **.env.example**).
2. **`npm run dev`** → servidor debe iniciar normalmente.
3. Ir a **`/products`** → las cards deben mostrar el nombre de la categoría.

## Issue que cierra

Close #107 