### PR TITLE
chore: instalar express-validator y crear archivos de validadores

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "ejs": "^5.0.2",
         "express": "^5.2.1",
         "express-session": "^1.19.0",
+        "express-validator": "^7.3.2",
         "method-override": "^3.0.0",
         "multer": "^2.1.1",
         "mysql2": "^3.22.3",
@@ -871,6 +872,19 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/express-validator": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.3.2.tgz",
+      "integrity": "sha512-ctLw1Vl6dXVH62dIQMDdTAQkrh480mkFuG6/SGXOaVlwPNukhRAe7EgJIMJ2TSAni8iwHBRp530zAZE5ZPF2IA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.18.1",
+        "validator": "~13.15.23"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/fill-range": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "ejs": "^5.0.2",
     "express": "^5.2.1",
     "express-session": "^1.19.0",
+    "express-validator": "^7.3.2",
     "method-override": "^3.0.0",
     "multer": "^2.1.1",
     "mysql2": "^3.22.3",

--- a/src/middlewares/validators/product.validators.js
+++ b/src/middlewares/validators/product.validators.js
@@ -1,0 +1,37 @@
+// src/middlewares/validators/product.validators.js
+const { body } = require('express-validator');
+
+const ALLOWED_IMAGE_EXTENSIONS = /\.(jpg|jpeg|png|gif)$/i;
+
+const productValidators = [
+    body('name')
+        .trim()
+        .notEmpty().withMessage('El nombre del producto es obligatorio.')
+        .isLength({ min: 5 }).withMessage('El nombre debe tener al menos 5 caracteres.'),
+
+    body('description')
+        .trim()
+        .notEmpty().withMessage('La descripción es obligatoria.')
+        .isLength({ min: 20 }).withMessage('La descripción debe tener al menos 20 caracteres.'),
+
+    body('price')
+        .notEmpty().withMessage('El precio es obligatorio.')
+        .isFloat({ min: 0 }).withMessage('El precio debe ser un número válido mayor o igual a 0.'),
+
+    body('categoryId')
+        .notEmpty().withMessage('Seleccioná una categoría.'),
+
+    body('brandId')
+        .notEmpty().withMessage('Seleccioná una marca.'),
+
+    body('image')
+        .optional({ checkFalsy: true })
+        .custom((value) => {
+            if (value && !ALLOWED_IMAGE_EXTENSIONS.test(value)) {
+                throw new Error('La imagen debe ser JPG, JPEG, PNG o GIF.');
+            }
+            return true;
+        }),
+];
+
+module.exports = { productValidators };

--- a/src/middlewares/validators/user.validators.js
+++ b/src/middlewares/validators/user.validators.js
@@ -1,0 +1,44 @@
+// src/middlewares/validators/user.validators.js
+const { body } = require('express-validator');
+
+const registerValidators = [
+    body('firstName')
+        .trim()
+        .notEmpty().withMessage('El nombre es obligatorio.')
+        .isLength({ min: 2 }).withMessage('El nombre debe tener al menos 2 caracteres.'),
+
+    body('lastName')
+        .trim()
+        .notEmpty().withMessage('El apellido es obligatorio.')
+        .isLength({ min: 2 }).withMessage('El apellido debe tener al menos 2 caracteres.'),
+
+    body('email')
+        .trim()
+        .notEmpty().withMessage('El correo electrónico es obligatorio.')
+        .isEmail().withMessage('El formato del correo no es válido.'),
+
+    body('password')
+        .notEmpty().withMessage('La contraseña es obligatoria.')
+        .isLength({ min: 8 }).withMessage('La contraseña debe tener al menos 8 caracteres.'),
+
+    body('password2')
+        .notEmpty().withMessage('Repetí la contraseña.')
+        .custom((value, { req }) => {
+            if (value !== req.body.password) {
+                throw new Error('Las contraseñas no coinciden.');
+            }
+            return true;
+        }),
+];
+
+const loginValidators = [
+    body('email')
+        .trim()
+        .notEmpty().withMessage('El correo electrónico es obligatorio.')
+        .isEmail().withMessage('El formato del correo no es válido.'),
+
+    body('password')
+        .notEmpty().withMessage('La contraseña es obligatoria.'),
+];
+
+module.exports = { registerValidators, loginValidators };


### PR DESCRIPTION
## ¿Qué hace este PR?

Instala express-validator y crea los archivos de validadores que serán usados como middlewares más adelante.

## Dependencia instalada

- **`express-validator`** — middleware para validar y sanear datos de formularios.

## Estructura creada

```bash
src/middlewares/validators/
├── user.validators.js      ← registerValidators + loginValidators
└── product.validators.js   ← productValidators
```

## Decisiones de diseño

- Los validadores viven en **`src/middlewares/validators/`** separados por entidad, no inline en las rutas. Esto mantiene la separación de responsabilidades y facilita reutilizarlos o modificarlos.
- Cada archivo exporta arrays de middlewares listos para usar directamente en las rutas: **`router.post('/register', registerValidators, controller)`.**

## Archivos agregados

- **`src/middlewares/validators/user.validators.js`**.
- **`src/middlewares/validators/product.validators.js`**.

## Issue que cierra

Close #108 