### PR TITLE
fix: agregar isAdmin, error.ejs y proteger rutas de escritura de productos

### DIFF
--- a/src/controllers/products.controller.js
+++ b/src/controllers/products.controller.js
@@ -1,3 +1,4 @@
+// src/controllers/products.controller.js
 const { Product, Category, Brand } = require('../../database/models');
 const { Op } = require('sequelize');
 const { validationResult } = require('express-validator');
@@ -40,7 +41,11 @@ const productsController = {
             });
         } catch (err) {
             console.error(err);
-            res.status(500).render('404', { title: 'Error', session: req.session });
+            res.status(500).render('error', {
+                title:   'Error del servidor',
+                message: 'No se pudo cargar el listado de productos.',
+                session: req.session
+            });
         }
     },
 
@@ -52,7 +57,10 @@ const productsController = {
                     { model: Brand,    as: 'brand'    },
                 ]
             });
-            if (!product) return res.status(404).render('404', { title: 'Producto no encontrado', session: req.session });
+            if (!product) return res.status(404).render('404', {
+                title:   'Producto no encontrado',
+                session: req.session
+            });
             res.render('products/detail', {
                 title:   `${product.name} – LuBo`,
                 product,
@@ -60,7 +68,11 @@ const productsController = {
             });
         } catch (err) {
             console.error(err);
-            res.status(500).render('404', { title: 'Error', session: req.session });
+            res.status(500).render('error', {
+                title:   'Error del servidor',
+                message: 'No se pudo cargar el producto.',
+                session: req.session
+            });
         }
     },
 
@@ -80,7 +92,11 @@ const productsController = {
             });
         } catch (err) {
             console.error(err);
-            res.status(500).render('404', { title: 'Error', session: req.session });
+            res.status(500).render('error', {
+                title:   'Error del servidor',
+                message: 'No se pudo cargar el formulario de creación.',
+                session: req.session
+            });
         }
     },
 
@@ -88,18 +104,27 @@ const productsController = {
         const result = validationResult(req);
 
         if (!result.isEmpty()) {
-            const [categories, brands] = await Promise.all([
-                Category.findAll(),
-                Brand.findAll()
-            ]);
-            return res.render('products/create', {
-                title:      'Nuevo Producto – LuBo',
-                categories,
-                brands,
-                errors:     result.array().map(e => e.msg),
-                old:        req.body,
-                session:    req.session
-            });
+            try {
+                const [categories, brands] = await Promise.all([
+                    Category.findAll(),
+                    Brand.findAll()
+                ]);
+                return res.render('products/create', {
+                    title:      'Nuevo Producto – LuBo',
+                    categories,
+                    brands,
+                    errors:     result.array().map(e => e.msg),
+                    old:        req.body,
+                    session:    req.session
+                });
+            } catch (err) {
+                console.error(err);
+                return res.status(500).render('error', {
+                    title:   'Error del servidor',
+                    message: 'No se pudo cargar el formulario.',
+                    session: req.session
+                });
+            }
         }
 
         try {
@@ -115,7 +140,11 @@ const productsController = {
             res.redirect('/products');
         } catch (err) {
             console.error(err);
-            res.status(500).render('404', { title: 'Error al crear', session: req.session });
+            res.status(500).render('error', {
+                title:   'Error del servidor',
+                message: 'No se pudo crear el producto.',
+                session: req.session
+            });
         }
     },
 
@@ -126,7 +155,10 @@ const productsController = {
                 Category.findAll(),
                 Brand.findAll()
             ]);
-            if (!product) return res.status(404).render('404', { title: 'Producto no encontrado', session: req.session });
+            if (!product) return res.status(404).render('404', {
+                title:   'Producto no encontrado',
+                session: req.session
+            });
             res.render('products/edit', {
                 title:      `Editar: ${product.name} – LuBo`,
                 product,
@@ -138,7 +170,11 @@ const productsController = {
             });
         } catch (err) {
             console.error(err);
-            res.status(500).render('404', { title: 'Error', session: req.session });
+            res.status(500).render('error', {
+                title:   'Error del servidor',
+                message: 'No se pudo cargar el formulario de edición.',
+                session: req.session
+            });
         }
     },
 
@@ -146,25 +182,37 @@ const productsController = {
         const result = validationResult(req);
 
         if (!result.isEmpty()) {
-            const [product, categories, brands] = await Promise.all([
-                Product.findByPk(req.params.id),
-                Category.findAll(),
-                Brand.findAll()
-            ]);
-            return res.render('products/edit', {
-                title:      `Editar: ${product ? product.name : 'Producto'} – LuBo`,
-                product,
-                categories,
-                brands,
-                errors:     result.array().map(e => e.msg),
-                old:        req.body,
-                session:    req.session
-            });
+            try {
+                const [product, categories, brands] = await Promise.all([
+                    Product.findByPk(req.params.id),
+                    Category.findAll(),
+                    Brand.findAll()
+                ]);
+                return res.render('products/edit', {
+                    title:      `Editar: ${product ? product.name : 'Producto'} – LuBo`,
+                    product,
+                    categories,
+                    brands,
+                    errors:     result.array().map(e => e.msg),
+                    old:        req.body,
+                    session:    req.session
+                });
+            } catch (err) {
+                console.error(err);
+                return res.status(500).render('error', {
+                    title:   'Error del servidor',
+                    message: 'No se pudo cargar el formulario de edición.',
+                    session: req.session
+                });
+            }
         }
 
         try {
             const product = await Product.findByPk(req.params.id);
-            if (!product) return res.status(404).render('404', { title: 'Producto no encontrado', session: req.session });
+            if (!product) return res.status(404).render('404', {
+                title:   'Producto no encontrado',
+                session: req.session
+            });
             const { name, description, image, categoryId, brandId, price } = req.body;
             await product.update({
                 name,
@@ -177,7 +225,11 @@ const productsController = {
             res.redirect(`/products/${product.id}`);
         } catch (err) {
             console.error(err);
-            res.status(500).render('404', { title: 'Error al editar', session: req.session });
+            res.status(500).render('error', {
+                title:   'Error del servidor',
+                message: 'No se pudo guardar los cambios del producto.',
+                session: req.session
+            });
         }
     },
 
@@ -188,7 +240,11 @@ const productsController = {
             res.redirect('/products');
         } catch (err) {
             console.error(err);
-            res.status(500).render('404', { title: 'Error al eliminar', session: req.session });
+            res.status(500).render('error', {
+                title:   'Error del servidor',
+                message: 'No se pudo eliminar el producto.',
+                session: req.session
+            });
         }
     }
 };

--- a/src/middlewares/auth.middleware.js
+++ b/src/middlewares/auth.middleware.js
@@ -1,4 +1,3 @@
-// src/middlewares/auth.middleware.js
 const { User } = require('../../database/models');
 
 // Middleware de aplicación: auto-login por cookie "recordarme"
@@ -39,4 +38,14 @@ const isGuest = (req, res, next) => {
     res.redirect('/users/profile');
 };
 
-module.exports = { rememberMe, isAuthenticated, isGuest };
+// Middleware: solo usuarios admin
+const isAdmin = (req, res, next) => {
+    if (req.session.user && req.session.user.category === 'admin') return next();
+    res.status(403).render('error', {
+        title: 'Acceso denegado',
+        message: 'No tenés permisos para realizar esta acción.',
+        session: req.session
+    });
+};
+
+module.exports = { rememberMe, isAuthenticated, isGuest, isAdmin };

--- a/src/public/css/style.css
+++ b/src/public/css/style.css
@@ -713,6 +713,26 @@ body {
 }
 
 /* ===========================================
+   PRODUCT ACTIONS
+   =========================================== */
+.product-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin: 1.5rem 0;
+}
+
+.product-actions-admin {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+}
+
+.btn-full {
+    width: 100%;
+}
+
+/* ===========================================
    CARRITO
    =========================================== */
 .cart-page { padding: 3rem 0 6rem; }
@@ -1527,6 +1547,55 @@ body {
 }
 .error-list li + li {
   margin-top: 0.2rem;
+}
+
+/* ===========================================
+   ERROR PAGE
+   =========================================== */
+.error-page {
+    text-align: center;
+    padding: 4rem 0;
+}
+
+.error-page-msg {
+    color: var(--ink-muted);
+    margin: 1.5rem 0;
+}
+
+/* ===========================================
+   404 PAGE
+   =========================================== */
+.page-404 {
+    padding: 6rem 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    text-align: center;
+    width: 100%;
+}
+
+.page-404 .container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+}
+
+.error-code {
+    font-family: var(--font-display);
+    font-size: 8rem;
+    font-weight: 300;
+    color: var(--ink-muted);
+    line-height: 1;
+    margin-bottom: 1rem;
+}
+
+.error-msg {
+    font-size: 1.1rem;
+    color: var(--ink-muted);
+    margin-bottom: 2rem;
+    text-align: center;
 }
 
 /* ===========================================

--- a/src/routes/products.routes.js
+++ b/src/routes/products.routes.js
@@ -1,18 +1,18 @@
 const express = require('express');
 const router = express.Router();
 const productsController = require('../controllers/products.controller');
-const { isAuthenticated } = require('../middlewares/auth.middleware');
+const { isAuthenticated, isAdmin } = require('../middlewares/auth.middleware');
 const { productValidators } = require('../middlewares/validators/product.validators');
 
-// Rutas estáticas primero (antes de las que tienen :id)
-router.get('/',         productsController.list);
-router.get('/create',   isAuthenticated, productsController.createForm);
-router.post('/',        isAuthenticated, productValidators, productsController.create);
+// Rutas estáticas primero
+router.get('/',           productsController.list);
+router.get('/create',     isAuthenticated, isAdmin, productsController.createForm);
+router.post('/',          isAuthenticated, isAdmin, productValidators, productsController.create);
 
 // Rutas con parámetro :id después
-router.get('/:id/edit', isAuthenticated, productsController.editForm);
-router.put('/:id',      isAuthenticated, productValidators, productsController.edit);
-router.delete('/:id',   isAuthenticated, productsController.destroy);
-router.get('/:id',      productsController.detail);
+router.get('/:id',        productsController.detail);
+router.get('/:id/edit',   isAuthenticated, isAdmin, productsController.editForm);
+router.put('/:id',        isAuthenticated, isAdmin, productValidators, productsController.edit);
+router.delete('/:id',     isAuthenticated, isAdmin, productsController.destroy);
 
 module.exports = router;

--- a/src/views/404.ejs
+++ b/src/views/404.ejs
@@ -1,24 +1,17 @@
 <!DOCTYPE html>
-<html lang="en">
-
+<html lang="es">
 <%- include('partials/head') %>
-
 <body>
-    
-    <!-- HEADER -->
     <%- include('partials/header') %>
 
-    <!-- MAIN -->
-    <main class="page-content page-404">
-        <div class="container text-center">
+    <main class="page-404">
+        <div class="container">
             <h1 class="error-code">404</h1>
             <p class="error-msg">La página que buscás no existe.</p>
-            <a href="/" class="btn-primary">Volver al inicio</a>
+            <a href="/" class="btn btn-accent">Volver al inicio</a>
         </div>
     </main>
-    
-    <!-- FOOTER -->
-    <%- include('partials/footer') %>
 
+    <%- include('partials/footer') %>
 </body>
 </html>

--- a/src/views/error.ejs
+++ b/src/views/error.ejs
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="es">
+<%- include('partials/head') %>
+<body>
+    <%- include('partials/header') %>
+    <main class="section">
+        <div class="container container-narrow error-page">
+            <span class="eyebrow">Error</span>
+            <h1 class="form-title"><%= title || 'Error del servidor' %></h1>
+            <p class="error-page-msg">
+                <%= message || 'Ocurrió un error inesperado. Por favor, intentá de nuevo.' %>
+            </p>
+            <a href="/" class="btn btn-accent">Volver al inicio</a>
+        </div>
+    </main>
+    <%- include('partials/footer') %>
+</body>
+</html>

--- a/src/views/products/detail.ejs
+++ b/src/views/products/detail.ejs
@@ -58,18 +58,22 @@
                         </div>
                     <% } %>
 
-                    <div class="add-to-cart-section">
-                        <button class="btn btn-accent btn-cart">Agregar al carrito</button>
-                        <a href="/products/<%= product.id %>/edit" class="btn btn-outline">Editar producto</a>
-                    </div>
+                    <div class="product-actions">
+                        <button class="btn btn-accent btn-full">Agregar al carrito</button>
 
-                    <div class="detail-delete-section">
-                        <form action="/products/<%= product.id %>?_method=DELETE" method="POST"
-                              onsubmit="return confirm('¿Estás seguro de que querés eliminar este producto?')">
-                            <button type="submit" class="btn btn-outline btn-danger">
-                                Eliminar producto
-                            </button>
-                        </form>
+                        <% if (session && session.user && session.user.category === 'admin') { %>
+                            <div class="product-actions-admin">
+                                <a href="/products/<%= product.id %>/edit" class="btn btn-outline btn-full">
+                                    Editar producto
+                                </a>
+                                <form action="/products/<%= product.id %>?_method=DELETE" method="POST"
+                                    onsubmit="return confirm('¿Estás seguro de que querés eliminar este producto?')">
+                                    <button type="submit" class="btn btn-outline btn-danger btn-full">
+                                        Eliminar producto
+                                    </button>
+                                </form>
+                            </div>
+                        <% } %>
                     </div>
 
                     <div class="product-meta">


### PR DESCRIPTION
## ¿Qué hace este PR?

Resuelve tres puntos de deuda técnica detectados en la revisión del Sprint 7.

## Cambios realizados

- **`src/middlewares/auth.middleware.js`**: se agrega **`isAdmin`**, middleware que verifica **`category === 'admin'`** y responde 403 con **`error.ejs`** si no se cumple.
- **`src/routes/products.routes.js`**: rutas de creación, edición y eliminación ahora usan isAuthenticated + isAdmin en cadena.
- **`src/views/error.ejs`**: nueva vista para errores **`500`**, separada de **`404.ejs`**.
- **`src/controllers/products.controller.js`**: todos los catch renderizan error.ejs.
- **`src/views/products/detail.ejs`**: botones Editar y Eliminar visibles solo para admin.

## Cómo probarlo

1. Loguearse como cliente → intentar ir a **`/products/create`** → "Acceso denegado".
2. Loguearse como admin → **`/products/create`** debe cargar normalmente.
3. Vista de detalle → botones de admin solo visibles para **`category === 'admin'`**.

## Issue que cierra

Close #131 