### PR TITLE
feature: paginado opcional en API de usuarios y productos

### DIFF
--- a/src/controllers/api.products.controller.js
+++ b/src/controllers/api.products.controller.js
@@ -6,24 +6,40 @@ const apiProductsController = {
 
     list: async (req, res) => {
         try {
-            const products = await Product.findAll({
-                include: [
-                    { model: Category, as: 'category' },
-                    { model: Brand,    as: 'brand'    }
-                ],
-                order: [['createdAt', 'DESC']]
-            });
+            const PAGE_SIZE = 10;
+            const page   = parseInt(req.query.page) || 1;
+            const offset = (page - 1) * PAGE_SIZE;
 
-            // countByCategory: { 'Fichas Técnicas': 5, 'Moldes': 3, ... }
+            // countByCategory necesita el total completo (sin limit)
+            const allProducts = await Product.findAll({
+                include: [{ model: Category, as: 'category' }]
+            });
             const countByCategory = {};
-            products.forEach(p => {
+            allProducts.forEach(p => {
                 const catName = p.category ? p.category.name : 'Sin categoría';
                 countByCategory[catName] = (countByCategory[catName] || 0) + 1;
             });
 
+            const { count, rows: products } = await Product.findAndCountAll({
+                include: [
+                    { model: Category, as: 'category' },
+                    { model: Brand,    as: 'brand'    }
+                ],
+                order:    [['createdAt', 'DESC']],
+                limit:    PAGE_SIZE,
+                offset,
+                distinct: true
+            });
+
+            const totalPages = Math.ceil(count / PAGE_SIZE);
+
             res.json({
-                count: products.length,
+                count,
                 countByCategory,
+                page,
+                totalPages,
+                next:     page < totalPages ? `${BASE_URL}/api/products?page=${page + 1}` : null,
+                previous: page > 1         ? `${BASE_URL}/api/products?page=${page - 1}` : null,
                 products: products.map(p => ({
                     id:          p.id,
                     name:        p.name,

--- a/src/controllers/api.users.controller.js
+++ b/src/controllers/api.users.controller.js
@@ -6,11 +6,25 @@ const apiUsersController = {
 
     list: async (req, res) => {
         try {
-            const users = await User.findAll({
-                attributes: ['id', 'firstName', 'lastName', 'email', 'image', 'createdAt']
+            const PAGE_SIZE = 10;
+            const page   = parseInt(req.query.page) || 1;
+            const offset = (page - 1) * PAGE_SIZE;
+
+            const { count, rows: users } = await User.findAndCountAll({
+                attributes: ['id', 'firstName', 'lastName', 'email', 'image', 'createdAt'],
+                limit:  PAGE_SIZE,
+                offset,
+                order:  [['createdAt', 'DESC']]
             });
+
+            const totalPages = Math.ceil(count / PAGE_SIZE);
+
             res.json({
-                count: users.length,
+                count,
+                page,
+                totalPages,
+                next:     page < totalPages ? `${BASE_URL}/api/users?page=${page + 1}` : null,
+                previous: page > 1         ? `${BASE_URL}/api/users?page=${page - 1}` : null,
                 users: users.map(u => ({
                     id:     u.id,
                     name:   `${u.firstName} ${u.lastName}`,


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega paginado por querystring (**`?page=N`**) a los endpoints de listado de la API.

## Cambios realizados

- **`api.users.controller.js`**: list usa **`findAndCountAll`** con **`limit/offset`**. Incluye **`page`**, **`totalPages`**, **`next`** y **`previous`** en la respuesta.
- **`api.products.controller.js`**: mismo patrón. **`countByCategory`** sigue calculándose sobre el total completo (sin limit) para mantener precisión independiente de la página consultada.

## Decisión de diseño

**`countByCategory`** se calcula con una query separada sobre todos los productos (sin limit). Esto agrega una query extra pero garantiza que el conteo por categoría siempre sea correcto y no varíe según la página.

## Cómo probarlo

**`GET http://localhost:3000/api/users?page=1`**.
**`GET http://localhost:3000/api/products?page=1`**.
**`GET http://localhost:3000/api/products?page=2`**.

## Archivos modificados

- **`src/controllers/api.users.controller.js`**.
- **`src/controllers/api.products.controller.js`**.

## Issue que cierra

Close #134 