### PR TITLE
docs: README con API y dashboard + retro sprint 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Diseñadores de indumentaria, estudiantes de diseño, talleres y pequeños empre
 ## 🛠 Tecnologías utilizadas
 
 | Capa | Tecnología |
-|------|-----------| 
+|------|-----------|
 | Markup | HTML5 semántico |
 | Estilos | CSS3 (variables, grid, flexbox) |
 | Tipografías | Google Fonts: Cormorant Garamond + Inter |
@@ -43,8 +43,9 @@ Diseñadores de indumentaria, estudiantes de diseño, talleres y pequeños empre
 | Cookies | cookie-parser |
 | Upload de imagen | multer |
 | Validaciones | express-validator |
+| CORS | cors |
 | Variables de entorno | dotenv |
-| Frontend framework (próximo) | React |
+| Frontend framework | React |
 
 ---
 
@@ -83,6 +84,7 @@ DB_USER=root
 DB_PASS=tu_contraseña_local
 DB_NAME=lubo_db
 SESSION_SECRET=cualquier_string_secreto
+BASE_URL=http://localhost:3000
 ```
 
 ### 4. Iniciar el servidor
@@ -125,7 +127,9 @@ DPFS_francisco_schlusselblum/
 │   ├── controllers/
 │   │   ├── main.controller.js
 │   │   ├── products.controller.js
-│   │   └── users.controller.js
+│   │   ├── users.controller.js
+│   │   ├── api.users.controller.js
+│   │   └── api.products.controller.js
 │   ├── middlewares/
 │   │   ├── auth.middleware.js
 │   │   └── validators/
@@ -142,7 +146,8 @@ DPFS_francisco_schlusselblum/
 │   ├── routes/
 │   │   ├── main.routes.js
 │   │   ├── products.routes.js
-│   │   └── users.routes.js
+│   │   ├── users.routes.js
+│   │   └── api.routes.js
 │   └── views/
 │       ├── partials/
 │       │   ├── head.ejs
@@ -160,7 +165,21 @@ DPFS_francisco_schlusselblum/
 │       │   └── profile.ejs
 │       ├── index.ejs
 │       ├── cart.ejs
-│       └── 404.ejs
+│       ├── 404.ejs
+│       └── error.ejs
+├── dashboard/
+│   ├── package.json
+│   ├── public/
+│   └── src/
+│       ├── components/
+│       │   ├── Layout.jsx
+│       │   ├── StatCard.jsx
+│       │   ├── CategoryPanel.jsx
+│       │   ├── LastProduct.jsx
+│       │   └── ProductList.jsx
+│       ├── App.jsx
+│       ├── App.css
+│       └── index.js
 ├── design/
 └── wireframes/
 ```
@@ -173,12 +192,12 @@ DPFS_francisco_schlusselblum/
 |--------|------|-------------|------|
 | GET | / | Home con productos destacados | — |
 | GET | /products | Listado con filtro por categoría y búsqueda | — |
-| GET | /products/create | Formulario de creación | ✅ |
-| POST | /products | Acción de creación | ✅ |
+| GET | /products/create | Formulario de creación | ✅ Admin |
+| POST | /products | Acción de creación | ✅ Admin |
 | GET | /products/:id | Detalle de producto | — |
-| GET | /products/:id/edit | Formulario de edición | ✅ |
-| PUT | /products/:id | Acción de edición | ✅ |
-| DELETE | /products/:id | Acción de eliminación | ✅ |
+| GET | /products/:id/edit | Formulario de edición | ✅ Admin |
+| PUT | /products/:id | Acción de edición | ✅ Admin |
+| DELETE | /products/:id | Acción de eliminación | ✅ Admin |
 | GET | /users/register | Formulario de registro | — |
 | POST | /users/register | Acción de registro | — |
 | GET | /users/login | Formulario de login | — |
@@ -186,6 +205,41 @@ DPFS_francisco_schlusselblum/
 | GET | /users/profile | Perfil del usuario autenticado | ✅ |
 | POST | /users/logout | Cierre de sesión | ✅ |
 | GET | /cart | Carrito de compras | — |
+
+---
+
+## 🌐 API REST
+
+| Método | Endpoint | Descripción |
+|--------|----------|-------------|
+| GET | /api/users | Listado de usuarios (sin datos sensibles) |
+| GET | /api/users/:id | Detalle de usuario |
+| GET | /api/products | Listado de productos |
+| GET | /api/products/:id | Detalle de producto |
+
+Todos los endpoints de listado soportan paginado: `?page=N` (10 resultados por página).
+
+---
+
+## 🖥️ Dashboard React
+
+El dashboard es una SPA independiente ubicada en la carpeta `/dashboard`.
+
+### Cómo levantar el dashboard
+
+**Terminal 1 (servidor/API):**
+```bash
+npm run dev
+```
+
+**Terminal 2 (dashboard):**
+```bash
+cd dashboard
+npm start
+```
+
+El dashboard estará disponible en `http://localhost:3001`.  
+La API debe estar corriendo en `http://localhost:3000`.
 
 ---
 

--- a/retro.md
+++ b/retro.md
@@ -306,3 +306,53 @@ El Sprint 5 implementó el sistema de autenticación completo: registro con bcry
 ## 📝 Conclusión general
 
 El Sprint 6 completó la migración de la capa de datos de JSON a MySQL con Sequelize. La estructura de modelos, asociaciones y el DER quedaron bien definidos, y el servidor valida la conexión antes de iniciar. El punto más crítico fue una credencial hardcodeada en `config.js` en un repo público, resuelta en el Sprint 7 como primera acción. Para el Sprint 7 el foco está en validaciones front-end y back-end con express-validator, cerrando la protección de todos los formularios del sitio.
+
+---
+
+# 🌟 Retrospectiva — Sprint 7
+
+**Proyecto:** LuBo — Marketplace de recursos para diseño de indumentaria  
+**Dinámica:** Estrella de Mar
+
+---
+
+## ⬆️ Comenzar a hacer
+
+- Agregar el middleware de control de roles (`isAdmin`) desde el sprint en que se implementa autenticación, no esperar a que lo detecte una revisión externa.
+- Crear vistas de error diferenciadas (404 vs 500) desde el inicio del proyecto.
+
+---
+
+## ➕ Hacer más
+
+- Testear el flujo completo de validaciones (front y back) antes del merge a `main`.
+- Revisar que los mensajes de error sean consistentes en todas las vistas antes de cerrar cada issue.
+
+---
+
+## ✅ Continuar haciendo
+
+- Usar `express-validator` con re-render del form y `old` values para preservar los datos ingresados.
+- Separar los validators en archivos por entidad (`user.validators` / `product.validators`).
+- Mantener el archivo `.env.example` actualizado con cada nueva variable de entorno.
+- Workflow de branches y pull requests por cada issue.
+
+---
+
+## ➖ Hacer menos
+
+- Dejar la protección de rutas por rol para "el sprint que viene".
+- Usar la misma vista (`404.ejs`) para errores de tipos distintos.
+
+---
+
+## 🛑 Dejar de hacer
+
+- Renderizar `res.status(500)` con la vista `404` — confunde el tipo de error al usuario y dificulta el debugging.
+- Asumir que `isAuthenticated` es suficiente sin verificar el rol del usuario.
+
+---
+
+## 📝 Conclusión general
+
+El Sprint 7 completó el sistema de validaciones back-end y front-end con `express-validator` en todos los formularios. La arquitectura de middlewares quedó bien organizada y separada por responsabilidad. El punto débil fue la falta de control de roles (`isAdmin`), que permitía a cualquier usuario autenticado crear, editar y eliminar productos — corregido en el Sprint 8 como primera acción. Para el Sprint 8 el foco está en exponer una API REST y construir un dashboard en React que consuma esos datos.


### PR DESCRIPTION
## ¿Qué hace este PR?

Cierra el Sprint 8: documentación final, QA completo y retrospectiva del Sprint 7.

## Cambios en README.md

- Nueva sección **'🌐 API REST'** con tabla de endpoints y nota de paginado.
- Nueva sección **'🖥️ Dashboard React'** con instrucciones para levantar la SPA en una segunda terminal.
- Tabla de tecnologías: **`cors`** y **`React`** agregados.
- Estructura del proyecto: **`/dashboard`** y **`api.routes.js`** documentados.

## Cambios en retro.md

- Retrospectiva Sprint 7 con formato Estrella de Mar completo.
- 5 secciones + conclusión general que conecta con los objetivos del Sprint 8.

## QA realizado

Checklist completo verificado: endpoints de API, dashboard, paginado, CORS y roles.

## Archivos modificados

- **`README.md`**.
- **`retro.md`**.

## Issue que cierra

Close #140 